### PR TITLE
Refactor API and Enable job grouping

### DIFF
--- a/clowdr/__init__.py
+++ b/clowdr/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from .task import TaskHandler
 from .controller import metadata, launcher
 from .endpoint import AWS, remote
-from .driver import local, cluster, cloud, share
+from .driver import local, cloud, share
 
 __all__ = ['task', 'controller', 'driver', 'endpoint']
 

--- a/clowdr/controller/metadata.py
+++ b/clowdr/controller/metadata.py
@@ -43,7 +43,7 @@ def consolidateTask(tool, invocation, clowdrloc, dataloc, **kwargs):
     """
 
     ts = time.time()
-    dt = datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d')
+    dt = datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d_%H-%M-%S')
     randx = utils.randstring(8)
     modif = "{}-{}".format(dt, randx)
 

--- a/clowdr/driver.py
+++ b/clowdr/driver.py
@@ -120,7 +120,6 @@ def local(descriptor, invocation, provdir, **kwargs):
 
         if kwargs.get("cluster"):
             tmptaskgroup = " ".join(taskgroup)
-            print(tmptaskgroup)
             job.run(script.format(tmptaskgroup, taskdir))
         else:
             runtask(taskgroup, provdir=taskdir, local=True, **kwargs)

--- a/clowdr/driver.py
+++ b/clowdr/driver.py
@@ -7,7 +7,8 @@
 # Created by Greg Kiar on 2018-02-28.
 # Email: gkiar@mcin.ca
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawTextHelpFormatter
+import argparse
 import os.path as op
 import tempfile
 import json
@@ -140,7 +141,7 @@ def cluster(tool, invocation, clowdrloc, dataloc, cluster, **kwargs):
             slurm_args[k] = v
     job = Slurm(jobname, slurm_args)
 
-    script = "clowdr run {} -c {} --local"
+    script = "clowdr task {} -c {} --local"
     if kwargs.get("workdir"):
         script += " -w {}".format(kwargs["workdir"])
     if kwargs.get("volumes"):
@@ -235,69 +236,158 @@ def share(clowdrloc, **kwargs):
 def main(args=None):
     """main
     Command-line API wrapper for Clowdr as a CLI, not Python API.
+    For information about the command-line wrapper and arguments it accepts,
+    please try running "clowdr --help".
 
     Parameters
     ----------
     args: list
-        List of all command-line arguments being passed
+        List of all command-line arguments being passed.
 
     Returns
     -------
     int
-        The exit-code returned by the task being executed
+        The exit-code returned by the driver.
     """
-    desc = "Interface for launching Boutiques task locally and in the cloud"
-    parser = ArgumentParser("Clowdr CLI", description=desc)
-    subparsers = parser.add_subparsers(help="Modes of operation", dest="mode")
 
-    # Local Parser
-    parser_loc = subparsers.add_parser("local")
-    parser_loc.add_argument("tool", help="boutiques descriptor for a tool")
-    parser_loc.add_argument("invocation", help="input(s) for the tool")
-    parser_loc.add_argument("clowdrloc", help="location locally for clowdr")
-    parser_loc.add_argument("dataloc", help="location locally or s3 for data")
-    parser_loc.add_argument("--workdir", "-w", action="store")
-    parser_loc.add_argument("--volumes", "-v", action="append")
-    parser_loc.add_argument("--user", "-u", action="store_true")
+    # Create an outer argparser which can wrap subparsers for each function.
+    desc = """
+Scalable deployment and provenance-rich wrapper for Boutiques tools locally,
+on clusters, and in the cloud. For more information, go to our website:
 
-    parser_loc.add_argument("--verbose", "-V", action="store_true")
-    parser_loc.add_argument("--bids", "-b", action="store_true")
-    parser_loc.add_argument("--dev", "-d", action="store_true")
+     https://github.com/clowdr/clowdr.
+"""
+    parser = ArgumentParser("clowdr", description=desc,
+                            formatter_class=RawTextHelpFormatter)
+
+    htext = """Clowdr has several distinct modes of operation:
+  - local:  This mode allows you to develop your Clowdr execution, deploy
+            analyses on your local system, and deploy them on clusters.
+  - cloud:  This mode allows you to deploy your Clowdr exectuion on a cloud
+            resource. Currently, this only supports Amazon Web Services.
+  - share:  This mode launches a lightweight webserver for you to explore your
+            executions, monitor job progress, and share your results.
+  - task:   This mode is generally only for super-users. It is used by Clowdr
+            to launch your tasks and record provenance information from them
+            without you needing to call this option yourself. It can be useful
+            when debugging or re-running failed executions.
+"""
+    subparsers = parser.add_subparsers(dest="mode",
+                                       help=htext)
+
+    # Create the subparser for local/cluster execution.
+    desc = ("Manages local and cluster deployment. Ideal for development, "
+            "testing, executing on local resources, or deployment on a "
+            "computing cluster environment.")
+    parser_loc = subparsers.add_parser("local", description=desc)
+    parser_loc.add_argument("descriptor", type=argparse.FileType('r'),
+                            help="Local path to Boutiques descriptor for the "
+                                 "tool you wish to run. To learn about "
+                                 "descriptors and Boutiques, go to: "
+                                 "https://boutiques.github.io.")
+    parser_loc.add_argument("invocation",
+                            help="Local path to Boutiques invocation (or "
+                                 "directory containing multiple invocations) "
+                                 "for the analysis you wish to run. To learn "
+                                 "about invocations and Boutiques, go to: "
+                                 "https://boutiques.github.io.")
+    parser_loc.add_argument("provdir",
+                            help="Local directory for Clowdr provenance records"
+                                 " and other captured metadata to be stored. "
+                                 "This directory needs to exist prior to "
+                                 "running Clowdr.")
+
+    parser_loc.add_argument("--verbose", "-V", action="store_true",
+                            help="Toggles verbose output statements.")
+    parser_loc.add_argument("--dev", "-d", action="store_true",
+                            help="Launches only the first created task. This "
+                                 "is intended for development purposes.")
+    parser_loc.add_argument("--workdir", "-w", action="store",
+                            help="Specifies the working directory to be used "
+                                 "by the tasks created.")
+    parser_loc.add_argument("--volumes", "-v", action="append",
+                            help="Specifies any volumes to be mounted to the "
+                                 "container. This is usually related to the "
+                                 "path of any data files as specified in your "
+                                 "invocation(s).")
+    parser_loc.add_argument("--cluster", "-c", choices=["slurm"],
+                            help="If you wish to submit your local tasks to a "
+                                 "scheduler, you must specify it here. "
+                                 "Currently this only supports SLURM clusters.")
+    parser_loc.add_argument("--clusterargs", "-a", action="store",
+                            help="This allows users to supply arguments to the "
+                                 "cluster, such as specifying RAM or requesting"
+                                 " a certain amount of time on CPU. These are "
+                                 "provided in the form of key:value pairs, and "
+                                 "separated by commas. For example: "
+                                 "--clusterargs time:4:00,mem:2048,account:ABC")
+    parser_loc.add_argument("--jobname", "-n", action="store",
+                            help="If running on a cluster, and you wish to "
+                                 "specify a unique identifier to appear in the"
+                                 "submitted tasks, you can specify it with "
+                                 "this flag.")
+    parser_loc.add_argument("--simg", "-s", action="store",
+                            help="If the Boutiques descriptor summarizes a "
+                                 "tool wrapped in Singularity, and the image "
+                                 "has already been downloaded, this option "
+                                 "allows you to specify that image file.")
+    parser_loc.add_argument("--user", "-u", action="store_true",
+                            help="If the Boutiques descriptor summarizes a "
+                                 "tool wrapped in Docker, toggles propagating "
+                                 "the current user within the container.")
+    parser_loc.add_argument("--s3", action="store",
+                            help="Amazon S3 bucket and path for remote data. "
+                                 "Accepted in the format: s3://{bucket}/{path}")
+    parser_loc.add_argument("--bids", "-b", action="store_true",
+                            help="Indicates that the tool being launched is a "
+                                 "BIDS app. BIDS is a data organization format"
+                                 " in neuroimaging. For more information about"
+                                 " this, go to https://bids.neuroimaging.io.")
 
     parser_loc.set_defaults(func=local)
+    # parser_cls.set_defaults(func=cluster)
 
-    # Cluster Parser
-    parser_cls = subparsers.add_parser("cluster")
-    parser_cls.add_argument("tool", help="boutiques descriptor for a tool")
-    parser_cls.add_argument("invocation", help="input(s) for the tool")
-    parser_cls.add_argument("clowdrloc", help="location locally for clowdr")
-    parser_cls.add_argument("dataloc", help="location locally or s3 for data")
-    parser_cls.add_argument("cluster", help="cluster type", choices=["slurm"])
-    parser_cls.add_argument("--jobname", "-n", action="store")
-    parser_cls.add_argument("--slurm_args", action="store")
-    parser_cls.add_argument("--workdir", "-w", action="store")
-    parser_cls.add_argument("--volumes", "-v", action="append")
-    parser_cls.add_argument("--simg", "-s", action="store")
+    # Create the subparser for cloud execution.
+    desc = ("Manages local and cluster deployment. Ideal for development, "
+            "testing, executing on local resources, or deployment on a "
+            "computing cluster environment.")
+    parser_cld = subparsers.add_parser("cloud", description=desc)
+    parser_cld.add_argument("descriptor", type=argparse.FileType('r'),
+                            help="Local path to Boutiques descriptor for the "
+                                 "tool you wish to run. To learn about "
+                                 "descriptors and Boutiques, go to: "
+                                 "https://boutiques.github.io.")
+    parser_cld.add_argument("invocation",
+                            help="Local path to Boutiques invocation (or "
+                                 "directory containing multiple invocations) "
+                                 "for the analysis you wish to run. To learn "
+                                 "about invocations and Boutiques, go to: "
+                                 "https://boutiques.github.io.")
+    parser_cld.add_argument("provdir",
+                            help="Local directory for Clowdr provenance records"
+                                 " and other captured metadata to be stored. "
+                                 "This directory needs to exist prior to "
+                                 "running Clowdr.")
+    parser_cld.add_argument("s3",
+                            help="Amazon S3 bucket and path for remote data. "
+                                 "Accepted in the format: s3://{bucket}/{path}")
+    parser_cld.add_argument("cloud", choices=["aws"],
+                            help="cloud endpoint")
+    parser_cld.add_argument("auth",
+                            help="credentials for the remote resource")
 
-    parser_cls.add_argument("--verbose", "-V", action="store_true")
-    parser_cls.add_argument("--bids", "-b", action="store_true")
-    parser_cls.add_argument("--dev", "-d", action="store_true")
-
-    parser_cls.set_defaults(func=cluster)
-
-    # Cloud Parser
-    parser_cld = subparsers.add_parser("cloud")
-    parser_cld.add_argument("tool",  help="boutiques descriptor for a tool")
-    parser_cld.add_argument("invocation", help="input(s) for the tool")
-    parser_cld.add_argument("clowdrloc", help="location on s3 for clowdr")
-    parser_cld.add_argument("dataloc", help="location on s3 of data")
-    parser_cld.add_argument("cloud", help="cloud endpoint", choices=["aws"])
-    parser_cld.add_argument("auth", help="credentials for the remote resource")
-    parser_cld.add_argument("--region", "-r", action="store")
-
-    parser_cld.add_argument("--verbose", "-V", action="store_true")
-    parser_cld.add_argument("--bids", "-b", action="store_true")
-    parser_cld.add_argument("--dev", "-d", action="store_true")
+    parser_cld.add_argument("--verbose", "-V", action="store_true",
+                            help="Toggles verbose output statements.")
+    parser_cld.add_argument("--dev", "-d", action="store_true",
+                            help="Launches only the first created task. This "
+                                 "is intended for development purposes.")
+    parser_cld.add_argument("--region", "-r", action="store",
+                            help="")
+    parser_cld.add_argument("--bids", "-b", action="store_true",
+                            help="Indicates that the tool being launched is a "
+                                 "BIDS app. BIDS is a data organization format"
+                                 " in neuroimaging. For more information about"
+                                 " this, go to https://bids.neuroimaging.io.")
 
     parser_cld.set_defaults(func=cloud)
 
@@ -308,18 +398,18 @@ def main(args=None):
 
     parser_shr.set_defaults(func=share)
 
-    # Run Parser
-    parser_run = subparsers.add_parser("run")
-    parser_run.add_argument("metadata", help="task metadata file")
-    parser_run.add_argument("--clowdrloc", "-c", action="store",
-                            help="task output directory")
-    parser_run.add_argument("--local", "-l", action="store_true")
-    parser_run.add_argument("--workdir", "-w", action="store")
-    parser_run.add_argument("--volumes", "-v", action="append")
+    # Task Parser
+    parser_task = subparsers.add_parser("task")
+    parser_task.add_argument("metadata", help="task metadata file")
+    parser_task.add_argument("--clowdrloc", "-c", action="store",
+                             help="task output directory")
+    parser_task.add_argument("--local", "-l", action="store_true")
+    parser_task.add_argument("--workdir", "-w", action="store")
+    parser_task.add_argument("--volumes", "-v", action="append")
 
-    parser_run.add_argument("--verbose", "-V", action="store_true")
+    parser_task.add_argument("--verbose", "-V", action="store_true")
 
-    parser_run.set_defaults(func=run)
+    parser_task.set_defaults(func=run)
 
     # Parse arguments
     inps = parser.parse_args(args) if args is not None else parser.parse_args()

--- a/clowdr/task.py
+++ b/clowdr/task.py
@@ -25,7 +25,6 @@ from clowdr import utils
 
 class TaskHandler:
     def __init__(self, taskfile, **kwargs):
-        print(taskfile)
         self.manageTask(taskfile, **kwargs)
 
     def manageTask(self, taskfile, provdir=None, verbose=False, **kwargs):

--- a/clowdr/task.py
+++ b/clowdr/task.py
@@ -24,33 +24,35 @@ from clowdr import utils
 
 
 class TaskHandler:
-    def __init__(self, metadata, **kwargs):
-        self.manageTask(metadata, **kwargs)
+    def __init__(self, taskfile, **kwargs):
+        print(taskfile)
+        self.manageTask(taskfile, **kwargs)
 
-    def manageTask(self, metadata, clowdrloc=None, verbose=False, **kwargs):
+    def manageTask(self, taskfile, provdir=None, verbose=False, **kwargs):
         # Get metadata
-        if clowdrloc is None:
+        if provdir is None:
             self.localtaskdir = "/clowtask/"
         else:
-            self.localtaskdir = clowdrloc
+            self.localtaskdir = provdir
 
-        self.localtaskdir = op.join(self.localtaskdir, "clowtask_"+utils.randstring(3))
+        # The below grabs an ID from the form: /some/path/to/fname-#.ext
+        self.task_id = taskfile.split('.')[0].split('-')[-1]
+
+        self.localtaskdir = op.join(self.localtaskdir, "clowtask_"+self.task_id)
         if not op.exists(self.localtaskdir):
             os.makedirs(self.localtaskdir)
 
         if(verbose):
             print("Fetching metadata...")
-        remotetaskdir = op.dirname(metadata)
-        metadata = utils.get(metadata, self.localtaskdir)[0]
-        self.task_id = metadata.split('.')[0].split('-')[-1]
-        # The above grabs an ID from the form: fname-#.ext
+        remotetaskdir = op.dirname(taskfile)
+        taskfile = utils.get(taskfile, self.localtaskdir)[0]
 
         # Parse metadata
-        metadata   = json.load(open(metadata))
-        descriptor = metadata['tool']
-        invocation = metadata['invocation']
-        input_data = metadata['dataloc']
-        output_loc = utils.truepath(metadata['taskloc'])
+        taskinfo   = json.load(open(taskfile))
+        descriptor = taskinfo['tool']
+        invocation = taskinfo['invocation']
+        input_data = taskinfo['dataloc']
+        output_loc = utils.truepath(taskinfo['taskloc'])
 
         if(verbose):
             print("Fetching descriptor and invocation...")

--- a/examples/invocation.json
+++ b/examples/invocation.json
@@ -1,6 +1,6 @@
 {
-    "bids_dir": "/project/6008063/gkiar/data/ds114/",
-    "output_dir_name": "/project/6008063/gkiar/data/ds114/derivatives/bids-example/",
+    "bids_dir": "/data/ds114/",
+    "output_dir_name": "/data/ds114/derivatives/bids-example/",
     "analysis_level": "participant",
     "participant_label": ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10"],
     "skip_validator": true


### PR DESCRIPTION
This PR contains:

- Merged `cluster` and `local` execution interfaces under the name `local` with the `--cluster` argument optionally specified
- Optional job grouping for `local` execution
- Added timestamps to created clowdr provenance folders